### PR TITLE
Add extras tab to fractales guide

### DIFF
--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -16,6 +16,7 @@
     <button class="item-tab-btn active" data-tab="tab-promedios">Promedios</button>
     <button class="item-tab-btn" data-tab="tab-precios">Precios y Materiales</button>
     <button class="item-tab-btn" data-tab="tab-resumen">Resumen y Profit</button>
+    <button class="item-tab-btn" data-tab="tab-extras">Extras</button>
   </nav>
   <div class="container">
     <main>
@@ -72,6 +73,69 @@
           <canvas id="abrir-vs-vender-chart" height="120"></canvas>
         </div>
       </div>
+      <div id="tab-extras" style="display:none;">
+        <div class="card" style="margin-top:32px;">
+          <div style="text-align: center;margin-bottom: 25px;">
+            <h2>Extras</h2>
+          </div>
+          <p>Esta secci&oacute;n es informaci&oacute;n complementaria al Profit. Tambi&eacute;n informaci&oacute;n interesante de obtenci&oacute;n de otros materiales.</p>
+        </div>
+
+        <div class="card" style="margin-top:32px;">
+          <table class="table-modern" style="margin-bottom:10px;">
+            <thead>
+              <tr><th colspan="2">Stack de encriptaciones</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Clave de encriptaci&oacute;n fractal x stack</td><td>25.35</td></tr>
+              <tr><td>Matriz estabilizadora (venta)</td><td>precio</td></tr>
+              <tr><td>Conversi&oacute;n (clave de encriptaci&oacute;n fractal)</td><td>25.35 * (precio matriz)</td></tr>
+            </tbody>
+          </table>
+          <p>&quot;Oro&quot; extra que se podr&iacute;a a&ntilde;adir al Profit.</p>
+        </div>
+
+        <div class="card" style="margin-top:32px;">
+          <table class="table-modern">
+            <thead>
+              <tr><th colspan="2">Pu&ntilde;ado de reliquias fractales</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Pu&ntilde;ado de reliquias fractales x stack</td><td>16.82</td></tr>
+              <tr><td>Abriendo &quot;Pu&ntilde;ado de reliquias fractales&quot;</td><td>3 reliquias fractal</td></tr>
+              <tr><td>Reliquias fractales x stack de encriptaci&oacute;n</td><td>50.46</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="card" style="margin-top:32px;">
+          <table class="table-modern">
+            <thead>
+              <tr><th colspan="2">Transformaci&oacute;n de materiales t5 a t6</th></tr>
+            </thead>
+            <tbody>
+              <tr><td colspan="2">De los materiales obtenidos se pueden transformar a materiales t6, con el siguiente m&eacute;todo.</td></tr>
+              <tr><td>Material t5</td><td>cantidad 50</td></tr>
+              <tr><td>Material t6</td><td>cantidad 1</td></tr>
+              <tr><td>Mont&oacute;n de polvo cristalino</td><td>cantidad</td></tr>
+              <tr><td>Piedra filosofal</td><td>cantidad 5</td></tr>
+            </tbody>
+          </table>
+          <p>Ver secci&oacute;n de &quot;Forja M&iacute;stica&quot;.</p>
+        </div>
+
+        <div class="card" style="margin-top:32px;">
+          <table class="table-modern">
+            <thead>
+              <tr><th>Infusiones de Agon&iacute;a</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Infusi&oacute;n de +1 se puede transformar en infusiones de +2, +3, etc. Pueden dar m&aacute;s profit dependiendo de la elecci&oacute;n</td></tr>
+              <tr><td>Ver secci&oacute;n de &quot;Comparativa de items&quot; y crear tabla comparativa.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        </div>
     </main>
   </div>
   <script src="js/formatGold.js"></script>


### PR DESCRIPTION
## Summary
- add Extras tab button to fractales-gold page
- include new tab with complementary profit information
- refactor Extras section using tables instead of bullet lists

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687153ad70448328abb193babf044af3