### PR TITLE
Show stable matrix price in extras

### DIFF
--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -90,11 +90,11 @@
               </tr>
               <tr>
                 <th><div class="dato-item">Matriz estabilizadora (venta)</div></th>
-                <td><div class="dato-item-info">precio</div></td>
+                <td><div id="matriz-precio" class="dato-item-info">-</div></td>
               </tr>
               <tr>
                 <th><div class="dato-item">Conversión indirecta (clave de encriptación fractal)</div></th>
-                <td><div class="dato-item-info"><p style="color:#16c198">25.35 × (precio matriz)</p></div></td>
+                <td><div id="conversion-indirecta" class="dato-item-info" style="color:#16c198">-</div></td>
               </tr>
               <tr><th><div class="dato-item"><p>"Oro" extra que se podría añadir al Profit.</p></div></th></tr>
             </tbody>
@@ -172,7 +172,7 @@
     });
   </script>
   <script type="module">
-    import { renderGraficoContribuciones, renderGraficoAbrirVsVender, renderTablaPrecios, renderTablaPromedios, renderTablaResumenOro, renderTablaReferenciasProfit, fetchItemPrices, fetchIconsFor, ICON_ID_MAP } from './js/fractales-gold-ui.js';
+    import { renderGraficoContribuciones, renderGraficoAbrirVsVender, renderTablaPrecios, renderTablaPromedios, renderTablaResumenOro, renderTablaReferenciasProfit, renderExtras, fetchItemPrices, fetchIconsFor, ICON_ID_MAP } from './js/fractales-gold-ui.js';
 
     async function fetchPreciosFractales() {
       const priceMap = await fetchItemPrices([75919, 73248]);
@@ -194,6 +194,7 @@
       renderGraficoContribuciones(resumenData.contribuciones);
       renderTablaReferenciasProfit('tabla-referencias-profit', preciosFractales, resumenData);
       renderGraficoAbrirVsVender('abrir-vs-vender-chart', preciosFractales, resumenData);
+      renderExtras(preciosFractales, 24.96);
     }
 
     renderTodo();

--- a/js/fractales-gold-ui.js
+++ b/js/fractales-gold-ui.js
@@ -464,3 +464,16 @@ export function renderGraficoAbrirVsVender(containerId = 'abrir-vs-vender-chart'
     }
   });
 }
+
+export function renderExtras(preciosFractales = {}, claveStack = 24.96) {
+  const { venta73248 = 0 } = preciosFractales;
+  const precioMatrizEl = document.getElementById('matriz-precio');
+  const conversionEl = document.getElementById('conversion-indirecta');
+  if (precioMatrizEl) {
+    precioMatrizEl.textContent = window.formatGold(venta73248);
+  }
+  if (conversionEl) {
+    const total = Math.round(venta73248 * claveStack);
+    conversionEl.textContent = window.formatGold(total);
+  }
+}


### PR DESCRIPTION
## Summary
- show live market price for Stabilizing Matrix in the extras table
- compute indirect fractal key conversion value based on that price

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6871ad7725848328b119bbbdddf440cc