### PR TITLE
Corrige cálculo de costos y etiquetas

### DIFF
--- a/js/utils/Ingredient1gen.js
+++ b/js/utils/Ingredient1gen.js
@@ -305,7 +305,9 @@ export async function createIngredientTree(itemData, parent = null) {
     try {
       const prices = await gw2API.getItemPrices(ingredient.id);
       if (prices && prices.sells && prices.buys) {
-        ingredient.setPrices(prices.sells.unit_price, prices.buys.unit_price);
+        // Usar el precio de compra (buy order) como el valor barato y
+        // el precio de venta (sell listing) como el valor caro
+        ingredient.setPrices(prices.buys.unit_price, prices.sells.unit_price);
       } else {
         console.warn(`Precios no disponibles para ${ingredient.name} (${ingredient.id})`);
         ingredient.setPrices(0, 0);

--- a/js/utils/Ingredient3gen.js
+++ b/js/utils/Ingredient3gen.js
@@ -376,7 +376,9 @@ export async function createIngredientTree(itemData, parent = null) {
       const prices = await gw2API.getItemPrices(itemId);
 
       if (prices && prices.sells && prices.buys) {
-        ingredient.setPrices(prices.sells.unit_price, prices.buys.unit_price);
+        // Usar el precio de compra (buy order) como valor barato y
+        // el precio de venta (sell listing) como valor caro
+        ingredient.setPrices(prices.buys.unit_price, prices.sells.unit_price);
       } else {
         ingredient.setPrices(0, 0);
       }
@@ -398,7 +400,9 @@ export async function createIngredientTree(itemData, parent = null) {
         const prices = await gw2API.getItemPrices(ingredient.id);
 
         if (prices && prices.sells && prices.buys) {
-          ingredient.setPrices(prices.sells.unit_price, prices.buys.unit_price);
+          // Guardar el precio más barato como compra (buy order) y el más caro
+          // como venta (sell listing)
+          ingredient.setPrices(prices.buys.unit_price, prices.sells.unit_price);
         } else {
           ingredient.setPrices(0, 0);
         }


### PR DESCRIPTION
## Summary
- corregir obtención de precios para que `buy` sea el valor barato y `sell` el caro
- actualizar la etiqueta de la ganancia listada

## Testing
- `node --check js/utils/Ingredient1gen.js`
- `node --check js/utils/Ingredient3gen.js`
- `node --check js/legendaryCraftingBase.js`


------
https://chatgpt.com/codex/tasks/task_e_6871bcb79090832897ed15459ac01087