### PR TITLE
Corrige cálculo de ganancias con precio de compra

### DIFF
--- a/js/legendaryCraftingBase.js
+++ b/js/legendaryCraftingBase.js
@@ -287,25 +287,26 @@ export class LegendaryCraftingBase {
     if (this.summaryEl) this.summaryEl.style.display = 'none';
   }
 
-  renderProfitSummary(sellPrice, buyPrice, craftingCost) {
-    if (!this.summaryEl || !sellPrice || !craftingCost) return;
+  renderProfitSummary(buyPrice, craftingCost) {
+    if (!this.summaryEl || !buyPrice || !craftingCost) return;
     const existing = this.summaryEl.querySelectorAll('.summary-profit');
     existing.forEach(s => s.remove());
-    const profitSell = Math.round((sellPrice * 0.85) - craftingCost);
-    const profitBuy = Math.round((buyPrice * 0.85) - craftingCost);
+    const price85 = Math.round(buyPrice * 0.85);
+    const profitSell = price85 - craftingCost;
+    const profitBuy = price85 - craftingCost;
     const profitEl = document.createElement('div');
     profitEl.className = 'summary-profit';
     profitEl.innerHTML = `
       <h3>Resumen de Ganancias</h3>
-      <div class="summary-subsection">
-        <h4>Por venta listada</h4>
-        <div class="summary-item"><span>Precio de venta (85%):</span><span>${formatGold(Math.round(sellPrice * 0.85))}</span></div>
+        <div class="summary-subsection">
+          <h4>Por venta listada</h4>
+          <div class="summary-item"><span>Precio de compra (85%):</span><span>${formatGold(price85)}</span></div>
         <div class="summary-item"><span>Costo de crafteo:</span><span>${formatGold(craftingCost)}</span></div>
         <div class="summary-item profit-total"><strong>Ganancia estimada:</strong><strong style="color: ${profitSell >= 0 ? 'var(--success)' : 'var(--error)'};">${formatGold(profitSell)}</strong></div>
       </div>
       <div class="summary-subsection" style="margin-top: 15px;">
         <h4>Por venta directa</h4>
-        <div class="summary-item"><span>Precio de compra (85%):</span><span>${formatGold(Math.round(buyPrice * 0.85))}</span></div>
+        <div class="summary-item"><span>Precio de compra (85%):</span><span>${formatGold(price85)}</span></div>
         <div class="summary-item"><span>Costo de crafteo:</span><span>${formatGold(craftingCost)}</span></div>
         <div class="summary-item profit-total"><strong>Ganancia estimada:</strong><strong style="color: ${profitBuy >= 0 ? 'var(--success)' : 'var(--error)'};">${formatGold(profitBuy)}</strong></div>
       </div>
@@ -316,24 +317,32 @@ export class LegendaryCraftingBase {
   renderSummary() {
     if (!this.currentTree) return;
     const totals = this.currentTree.calculateTotals();
-    const totalBuy = totals.buy;
-    const totalSell = totals.sell;
+    const totalBuy = totals.buy; // Precio de compra (orden de compra)
+    const totalSell = totals.sell; // Precio de venta (orden de venta)
     const isCraftable = totals.isCraftable;
 
     const calculateCraftingCost = (ingredient) => {
       let cost = 0;
       if (ingredient.components && ingredient.components.length > 0) {
         ingredient.components.forEach(comp => { cost += calculateCraftingCost(comp); });
-      } else if (ingredient.buyPrice > 0) {
-        cost = ingredient.getTotalBuyPrice();
+      } else {
+        const buy = ingredient.getTotalBuyPrice();
+        const sell = ingredient.getTotalSellPrice();
+        if (buy > 0 && sell > 0) {
+          cost = Math.min(buy, sell);
+        } else if (buy > 0) {
+          cost = buy;
+        } else if (sell > 0) {
+          cost = sell;
+        }
       }
       return cost;
     };
 
     const craftingCost = calculateCraftingCost(this.currentTree);
     let html = `
-      <div class="summary-item"><span>Precio venta:</span><span>${totalBuy > 0 ? formatGold(totalBuy) : 'N/A'}</span></div>
-      <div class="summary-item"><span>Precio compra:</span><span>${totalSell > 0 ? formatGold(totalSell) : 'N/A'}</span></div>`;
+      <div class="summary-item"><span>Precio venta:</span><span>${totalSell > 0 ? formatGold(totalSell) : 'N/A'}</span></div>
+      <div class="summary-item"><span>Precio compra:</span><span>${totalBuy > 0 ? formatGold(totalBuy) : 'N/A'}</span></div>`;
     if (craftingCost > 0) {
       html += `<div class="summary-item"><strong>Costo de crafteo total:</strong><strong>${formatGold(craftingCost)}</strong></div>`;
     }
@@ -347,8 +356,9 @@ export class LegendaryCraftingBase {
     }
 
     this.summaryContentEl.innerHTML = html;
-    if (totalBuy > 0 && totalSell > 0 && craftingCost > 0) {
-      this.renderProfitSummary(totalBuy, totalSell, craftingCost);
+    if (totalBuy > 0 && craftingCost > 0) {
+      // Calcular ganancias usando el 85% del precio de compra total
+      this.renderProfitSummary(totalBuy, craftingCost);
     }
   }
 

--- a/js/utils/Ingredient1gen.js
+++ b/js/utils/Ingredient1gen.js
@@ -305,7 +305,9 @@ export async function createIngredientTree(itemData, parent = null) {
     try {
       const prices = await gw2API.getItemPrices(ingredient.id);
       if (prices && prices.sells && prices.buys) {
-        ingredient.setPrices(prices.sells.unit_price, prices.buys.unit_price);
+        // Usar el precio de compra (buy order) como el valor barato y
+        // el precio de venta (sell listing) como el valor caro
+        ingredient.setPrices(prices.buys.unit_price, prices.sells.unit_price);
       } else {
         console.warn(`Precios no disponibles para ${ingredient.name} (${ingredient.id})`);
         ingredient.setPrices(0, 0);

--- a/js/utils/Ingredient3gen.js
+++ b/js/utils/Ingredient3gen.js
@@ -376,7 +376,9 @@ export async function createIngredientTree(itemData, parent = null) {
       const prices = await gw2API.getItemPrices(itemId);
 
       if (prices && prices.sells && prices.buys) {
-        ingredient.setPrices(prices.sells.unit_price, prices.buys.unit_price);
+        // Usar el precio de compra (buy order) como valor barato y
+        // el precio de venta (sell listing) como valor caro
+        ingredient.setPrices(prices.buys.unit_price, prices.sells.unit_price);
       } else {
         ingredient.setPrices(0, 0);
       }
@@ -398,7 +400,9 @@ export async function createIngredientTree(itemData, parent = null) {
         const prices = await gw2API.getItemPrices(ingredient.id);
 
         if (prices && prices.sells && prices.buys) {
-          ingredient.setPrices(prices.sells.unit_price, prices.buys.unit_price);
+          // Guardar el precio más barato como compra (buy order) y el más caro
+          // como venta (sell listing)
+          ingredient.setPrices(prices.buys.unit_price, prices.sells.unit_price);
         } else {
           ingredient.setPrices(0, 0);
         }


### PR DESCRIPTION
## Summary
- usa siempre el precio de compra (más barato) para calcular la ganancia al 85%
- calcula el costo de crafteo con el precio más bajo entre compra y venta
- documenta que la ganancia se basa en el 85% de la compra

## Testing
- `node --check js/utils/Ingredient1gen.js`
- `node --check js/utils/Ingredient3gen.js`
- `node --check js/legendaryCraftingBase.js`


------
https://chatgpt.com/codex/tasks/task_e_6871bcb79090832897ed15459ac01087