### PR TITLE
Use Datawars2 prices in legendary crafting

### DIFF
--- a/js/legendaryCraftingBase.js
+++ b/js/legendaryCraftingBase.js
@@ -1,5 +1,6 @@
 // Shared logic for legendary crafting apps
 import { gw2API } from './services/GuildWars2API.js';
+import { dw2API } from './services/Datawars2API.js';
 
 export class LegendaryCraftingBase {
   constructor(config) {
@@ -396,8 +397,9 @@ export class LegendaryCraftingBase {
   }
 
   clearCache() {
-    const success = gw2API.clearCache();
-    if (success) {
+    const successGW2 = gw2API.clearCache();
+    const successDW2 = dw2API.clearCache ? dw2API.clearCache() : true;
+    if (successGW2 && successDW2) {
       alert('Caché limpiado correctamente');
       if (this.currentTree) this.loadItem({ itemId: this.itemIdInput?.value, itemName: this.itemNameInput?.value });
     } else {

--- a/js/services/Datawars2API.js
+++ b/js/services/Datawars2API.js
@@ -1,0 +1,98 @@
+/**
+ * Servicio para obtener precios de items desde Datawars2
+ */
+class Datawars2API {
+  constructor() {
+    this.BASE_URL = 'https://api.datawars2.ie/gw2/v1';
+    this.ITEMS_ENDPOINT = `${this.BASE_URL}/items/csv?fields=id,buy_price,sell_price&ids=`;
+    this.CACHE_PREFIX = 'dw2_api_cache_';
+    this.CACHE_DURATION = 6 * 60 * 60 * 1000; // 6 horas
+  }
+
+  /**
+   * Realiza una petición con soporte de caché
+   * @param {string} url
+   * @param {boolean} useCache
+   * @returns {Promise<string>} Respuesta de la petición
+   */
+  async _fetchWithCache(url, useCache = true) {
+    const cacheKey = this.CACHE_PREFIX + btoa(url);
+    if (useCache) {
+      try {
+        const cached = localStorage.getItem(cacheKey);
+        if (cached) {
+          const { data, timestamp } = JSON.parse(cached);
+          if (Date.now() - timestamp < this.CACHE_DURATION) {
+            return data;
+          }
+        }
+      } catch (e) {
+        console.warn('[Datawars2API] Error leyendo caché', e);
+      }
+    }
+
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const text = await response.text();
+    try {
+      localStorage.setItem(cacheKey, JSON.stringify({ data: text, timestamp: Date.now() }));
+    } catch (e) {
+      console.warn('[Datawars2API] No se pudo guardar en caché', e);
+    }
+    return text;
+  }
+
+  /**
+   * Parsea CSV simple a objeto con buy_price y sell_price
+   * @param {string} csvText
+   */
+  _parseCsv(csvText) {
+    const [headersLine, valuesLine] = csvText.trim().split('\n');
+    const headers = headersLine.split(',');
+    const values = valuesLine.split(',');
+    const obj = {};
+    headers.forEach((h, i) => {
+      const val = values[i];
+      obj[h] = val !== '' && val !== undefined ? val : '';
+    });
+    return obj;
+  }
+
+  /**
+   * Obtiene los precios de un item
+   * @param {number} itemId
+   */
+  async getItemPrices(itemId) {
+    if (!itemId) return { buys: { unit_price: 0 }, sells: { unit_price: 0 } };
+    const url = `${this.ITEMS_ENDPOINT}${itemId}`;
+    try {
+      const csvText = await this._fetchWithCache(url);
+      const data = this._parseCsv(csvText);
+      const buy = parseInt(data.buy_price || '0', 10);
+      const sell = parseInt(data.sell_price || '0', 10);
+      return { buys: { unit_price: buy || 0 }, sells: { unit_price: sell || 0 } };
+    } catch (e) {
+      console.error(`[Datawars2API] Error obteniendo precios para ${itemId}`, e);
+      return { buys: { unit_price: 0 }, sells: { unit_price: 0 } };
+    }
+  }
+
+  /**
+   * Limpia la caché de este servicio
+   */
+  clearCache() {
+    try {
+      Object.keys(localStorage).forEach(key => {
+        if (key.startsWith(this.CACHE_PREFIX)) {
+          localStorage.removeItem(key);
+        }
+      });
+      return true;
+    } catch (e) {
+      console.error('[Datawars2API] Error limpiando caché', e);
+      return false;
+    }
+  }
+}
+
+export const dw2API = new Datawars2API();

--- a/js/utils/Ingredient1gen.js
+++ b/js/utils/Ingredient1gen.js
@@ -303,7 +303,7 @@ export async function createIngredientTree(itemData, parent = null) {
     ingredient.setPrices(10000, 10000);
   } else if (isBasicMaterial(ingredient.id) && !shouldSkipMarketCheck(ingredient.id, ingredient.name)) {
     try {
-      const prices = await gw2API.getItemPrices(ingredient.id);
+      const prices = await dw2API.getItemPrices(ingredient.id);
         if (prices && prices.sells && prices.buys) {
           ingredient.setPrices(prices.buys.unit_price, prices.sells.unit_price);
       } else {
@@ -332,4 +332,5 @@ export async function createIngredientTree(itemData, parent = null) {
 
 // Importamos la API para usarla en esta función
 import { gw2API } from '../services/GuildWars2API.js';
+import { dw2API } from '../services/Datawars2API.js';
 import { isBasicMaterial } from '../data/legendaryItems1gen.js';

--- a/js/utils/Ingredient3gen.js
+++ b/js/utils/Ingredient3gen.js
@@ -373,7 +373,7 @@ export async function createIngredientTree(itemData, parent = null) {
     
     // Forzar la carga de precios para este ítem
     try {
-      const prices = await gw2API.getItemPrices(itemId);
+      const prices = await dw2API.getItemPrices(itemId);
 
           if (prices && prices.sells && prices.buys) {
             ingredient.setPrices(prices.buys.unit_price, prices.sells.unit_price);
@@ -395,7 +395,7 @@ export async function createIngredientTree(itemData, parent = null) {
     } else {
       
       try {
-        const prices = await gw2API.getItemPrices(ingredient.id);
+        const prices = await dw2API.getItemPrices(ingredient.id);
 
         if (prices && prices.sells && prices.buys) {
           ingredient.setPrices(prices.buys.unit_price, prices.sells.unit_price);
@@ -424,3 +424,4 @@ export async function createIngredientTree(itemData, parent = null) {
 
 // Importamos la API para usarla en esta función
 import { gw2API } from '../services/GuildWars2API.js';
+import { dw2API } from '../services/Datawars2API.js';


### PR DESCRIPTION
## Summary
- add `Datawars2API` service to fetch item prices using Datawars2
- use `dw2API.getItemPrices` in ingredient utilities
- expose `dw2API.clearCache()` through legendaryCraftingBase

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6873ef97d020832892a6cafa45d71fab