### PR TITLE
Fix tooltip HTML

### DIFF
--- a/js/formatGold.js
+++ b/js/formatGold.js
@@ -8,16 +8,20 @@ function formatGold(value) {
   const silver = Math.floor((absValue % 10000) / 100);
   const copper = absValue % 100;
 
-  let result = '';
+  let parts = [];
   if (gold > 0) {
-    result += `${gold}<img src="img/Gold_coin.png" alt="Gold" width="12"> ${silver.toString().padStart(2, '0')}<img src="img/Silver_coin.png" alt="Silver" width="12"> ${copper.toString().padStart(2, '0')}<img src="img/Copper_coin.png" alt="Copper" width="12">`;
+    parts.push(`${gold}g`);
+    parts.push(`${silver.toString().padStart(2, '0')}s`);
+    parts.push(`${copper.toString().padStart(2, '0')}c`);
   } else if (silver > 0) {
-    result += `${silver}<img src="img/Silver_coin.png" alt="Silver" width="12"> ${copper.toString().padStart(2, '0')}<img src="img/Copper_coin.png" alt="Copper" width="12">`;
+    parts.push(`${silver}s`);
+    parts.push(`${copper.toString().padStart(2, '0')}c`);
   } else {
-    result += `${copper.toString().padStart(2, '0')}<img src="img/Copper_coin.png" alt="Copper" width="12">`;
+    parts.push(`${copper}c`);
   }
 
-  if (isNegative) result = '-' + result.trim();
+  let result = parts.join(' ');
+  if (isNegative) result = '-' + result;
   return result.trim();
 }
 

--- a/js/legendaryCraftingBase.js
+++ b/js/legendaryCraftingBase.js
@@ -202,8 +202,8 @@ export class LegendaryCraftingBase {
       if (customText) {
         priceTooltip = customText.display;
       } else if ((ingredient.isPriceLoaded() || isLegendary || hasComponents) && (totalBuyPrice > 0 || totalSellPrice > 0)) {
-        const buyText = totalBuyPrice > 0 ? `Compra: ${formatGoldColored(totalBuyPrice)}` : 'Compra: N/A';
-        const sellText = totalSellPrice > 0 ? `Venta: ${formatGoldColored(totalSellPrice)}` : 'Venta: N/A';
+        const buyText = totalBuyPrice > 0 ? `Compra: ${formatGold(totalBuyPrice)}` : 'Compra: N/A';
+        const sellText = totalSellPrice > 0 ? `Venta: ${formatGold(totalSellPrice)}` : 'Venta: N/A';
         priceTooltip = `${buyText} | ${sellText}${(!hasBuyPrice || !hasSellPrice) && hasComponents ? ' (calculado de componentes)' : ''}`;
       } else if (hasComponents) {
         priceTooltip = 'Precio calculado de los componentes';


### PR DESCRIPTION
## Summary
- make `formatGold()` return plain text with coin letters
- avoid raw HTML in the tooltip by using `formatGold()`

## Testing
- `node --check js/formatGold.js`
- `node --check js/legendaryCraftingBase.js`


------
https://chatgpt.com/codex/tasks/task_e_6874814c67c8832883bd97447e8bd0a9