### PR TITLE
Add icons to Mystic Forge table

### DIFF
--- a/js/forja-mistica.js
+++ b/js/forja-mistica.js
@@ -1,5 +1,32 @@
 import { fetchItemPrices } from './fractales-gold-ui.js';
 
+// Cache local de iconos para esta página
+const iconCache = {};
+
+// Obtiene iconos desde la API de GW2 y los guarda en iconCache
+async function fetchIcons(ids = []) {
+  if (!ids.length) return;
+  try {
+    const res = await fetch(`https://api.guildwars2.com/v2/items?ids=${ids.join(',')}&lang=es`);
+    const data = await res.json();
+    data.forEach(item => {
+      if (item && item.id) iconCache[item.id] = item.icon;
+    });
+  } catch {
+    // Silenciar errores de carga de iconos
+  }
+}
+
+function addIconToCell(cell, icon) {
+  if (!cell || !icon) return;
+  const div = cell.querySelector('div');
+  if (!div || div.querySelector('img')) return;
+  const img = document.createElement('img');
+  img.src = icon;
+  img.className = 'item-icon';
+  div.prepend(img);
+}
+
 export const MATERIAL_IDS = {
   t6: {
     sangre: 24295,
@@ -32,6 +59,7 @@ export async function renderTablaForja() {
     MATERIAL_IDS.piedra
   ];
   const priceMap = await fetchItemPrices(ids);
+  await fetchIcons(ids);
 
   keys.forEach(key => {
     const row = document.querySelector(`#matt5t6 tr[data-key="${key}"]`);
@@ -53,7 +81,15 @@ export async function renderTablaForja() {
     if (sumEl) sumEl.innerHTML = window.formatGoldColored(sumMats);
     if (resEl) resEl.innerHTML = window.formatGoldColored(resultado);
     if (profitEl) profitEl.innerHTML = window.formatGoldColored(profit);
+
+    const cells = row.querySelectorAll('td');
+    addIconToCell(cells[0], iconCache[MATERIAL_IDS.t5[key]]);
+    addIconToCell(cells[1], iconCache[MATERIAL_IDS.t6[key]]);
+    addIconToCell(cells[2], iconCache[MATERIAL_IDS.polvo]);
+    addIconToCell(cells[3], iconCache[MATERIAL_IDS.piedra]);
   });
 }
 
-document.addEventListener('DOMContentLoaded', renderTablaForja);
+document.addEventListener('DOMContentLoaded', () => {
+  renderTablaForja();
+});


### PR DESCRIPTION
## Summary
- fetch GW2 icons for Mystic Forge materials
- insert icons into the Mystic Forge UI with `.item-icon` styling

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875577a52988328bd7d5694a9afa11b