### PR TITLE
Fix profit calculations for forging tables

### DIFF
--- a/js/forja-mistica.js
+++ b/js/forja-mistica.js
@@ -100,7 +100,7 @@ export async function renderTablaForja() {
 
     const sumMats = (50 * precioT5) + (5 * precioPolvo) + (5 * precioPiedra) + precioT6Buy;
     const resultado = 6.91 * precioT6Sell;
-    const profit = sumMats - resultado;
+    const profit = resultado - sumMats;
 
     if (sumEl) sumEl.innerHTML = window.formatGoldColored(sumMats);
     if (resEl) resEl.innerHTML = window.formatGoldColored(resultado);
@@ -140,7 +140,7 @@ export async function renderTablaLodestones() {
     const precioCristal = priceMap[LODESTONE_IDS.cristal]?.buy_price || 0;
 
     const sumMats = (2 * precioCore) + precioPolvo + precioBotella + precioCristal;
-    const profit = sumMats - precioLodestoneSell;
+    const profit = precioLodestoneSell - sumMats;
 
     if (sumEl) sumEl.innerHTML = window.formatGoldColored(sumMats);
     if (profitEl) profitEl.innerHTML = window.formatGoldColored(profit);


### PR DESCRIPTION
## Summary
- fix profit calculation in mystic forge material table
- fix profit calculation in lodestones table

## Testing
- `grep -n "profit" -n js/forja-mistica.js`


------
https://chatgpt.com/codex/tasks/task_e_687589d3619c8328a5e57a360701e9ef