### PR TITLE
Enable rarity color in search modal

### DIFF
--- a/compare-craft.html
+++ b/compare-craft.html
@@ -77,6 +77,7 @@
       <div id="modal-results" class="item-list"></div>
     </div>
   </div>
+  <script src="js/rarityUtils.js"></script>
   <script src="js/modal-utils.js"></script>
   <script>
   document.addEventListener('DOMContentLoaded', function() {

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
           <div id="modal-results" class="item-list"></div>
         </div>
       </div>
+      <script src="js/rarityUtils.js"></script>
       <script src="js/modal-utils.js"></script>
       <script>
       document.addEventListener('DOMContentLoaded', function() {

--- a/js/search-modal-compare-craft.js
+++ b/js/search-modal-compare-craft.js
@@ -15,6 +15,7 @@ const errorMessage = document.getElementById('modal-error-message');
 
 let allItems = [];
 let iconCache = {};
+let rarityCache = {};
 
 function showLoader(show) {
   loader.style.display = show ? 'block' : 'none';
@@ -81,9 +82,12 @@ function renderResults(items, showNoResults = false) {
     const card = document.createElement('div');
     card.className = 'item-card';
     card.onclick = (event) => window.selectItem(item.id, event);
+    const rarityClass = typeof getRarityClass === 'function'
+        ? getRarityClass(rarityCache[item.id])
+        : '';
     card.innerHTML = `
       <img src="${iconCache[item.id] || ''}" alt=""/>
-      <div class="item-name">${item.name_es}</div>
+      <div class="item-name ${rarityClass}">${item.name_es}</div>
       <div class="item-price" style="display:none;">Compra: ${item.buy_price || 0} | Venta: ${item.sell_price || 0}</div>
     `;
     fragment.appendChild(card);
@@ -106,6 +110,7 @@ async function fetchIconsFor(ids) {
     const data = await res.json();
     data.forEach(item => {
       iconCache[item.id] = item.icon;
+      rarityCache[item.id] = item.rarity;
     });
   } catch {}
 }

--- a/js/search-modal.js
+++ b/js/search-modal.js
@@ -12,6 +12,7 @@ const errorMessage = document.getElementById('modal-error-message');
 
 let allItems = [];
 let iconCache = {};
+let rarityCache = {};
 
 function showLoader(show) {
   loader.style.display = show ? 'block' : 'none';
@@ -84,9 +85,12 @@ function renderResults(items, showNoResults = false) {
     const card = document.createElement('div');
     card.className = 'item-card';
     card.onclick = () => selectItem(item.id);
+    const rarityClass = typeof getRarityClass === 'function'
+        ? getRarityClass(rarityCache[item.id])
+        : '';
     card.innerHTML = `
       <img src="${iconCache[item.id] || ''}" alt=""/>
-      <div class="item-name">${item.name_es}</div>
+      <div class="item-name ${rarityClass}">${item.name_es}</div>
       <div class="item-price" style="display:none;">Compra: ${formatGoldColored(item.buy_price)} | Venta: ${formatGoldColored(item.sell_price)}</div>
     `;
     fragment.appendChild(card);
@@ -115,6 +119,7 @@ async function fetchIconsFor(ids) {
     const data = await res.json();
     data.forEach(item => {
       iconCache[item.id] = item.icon;
+      rarityCache[item.id] = item.rarity;
     });
   } catch {}
 }


### PR DESCRIPTION
## Summary
- load rarityUtils in index and compare-craft pages
- capture item rarity when fetching icons
- use rarity class when rendering search results

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876836393748328b7f7aeddf4fc8953