### PR TITLE
Add rarity tracking to crafting utilities

### DIFF
--- a/js/compare-logic.js
+++ b/js/compare-logic.js
@@ -24,6 +24,7 @@ if (typeof window.comparativa === 'undefined') {
             id: itemData.id,
             name: itemData.name,
             icon: itemData.icon,
+            rarity: itemData.rarity,
             count: 1,
             buy_price: marketData.buy_price,
             sell_price: marketData.sell_price,
@@ -41,6 +42,7 @@ if (typeof window.comparativa === 'undefined') {
             id: itemData.id,
             name: itemData.name,
             icon: itemData.icon,
+            rarity: itemData.rarity,
             count: 1,
             buy_price: marketData.buy_price,
             sell_price: marketData.sell_price,
@@ -208,6 +210,7 @@ async function prepareIngredientTreeData(mainItemId, mainRecipeData) {
             id: itemDetail.id,
             name: itemDetail.name,
             icon: itemDetail.icon,
+            rarity: itemDetail.rarity,
             count: ingredientRecipeInfo.count,
             parentMultiplier: currentParentMultiplier,
             buy_price: marketInfo.buy_price !== undefined ? marketInfo.buy_price : null,
@@ -271,10 +274,11 @@ async function mainCompareUI() {
 mainCompareUI();
 
 export class CraftIngredient {
-  constructor({id, name, icon, count, parentMultiplier = 1, buy_price, sell_price, is_craftable, recipe, children, _parentId = null}) {
+  constructor({id, name, icon, rarity, count, parentMultiplier = 1, buy_price, sell_price, is_craftable, recipe, children, _parentId = null}) {
     this.id = id;
     this.name = name;
     this.icon = icon;
+    this.rarity = rarity;
     this.count = count; // Cantidad requerida por la receta padre
     this.parentMultiplier = parentMultiplier || 1;
     this.buy_price = buy_price;

--- a/js/crafting.js
+++ b/js/crafting.js
@@ -2,11 +2,12 @@
 // Lógica compartida para cálculo de crafteo y estructura de ingredientes
 
 class CraftIngredient {
-  constructor({id, name, icon, count, parentMultiplier = 1, buy_price, sell_price, crafted_price, is_craftable, recipe, children}) {
+  constructor({id, name, icon, rarity, count, parentMultiplier = 1, buy_price, sell_price, crafted_price, is_craftable, recipe, children}) {
     this.modeForParentCrafted = "buy";
     this.id = id;
     this.name = name;
     this.icon = icon;
+    this.rarity = rarity;
     this.count = count;
     this.parentMultiplier = parentMultiplier || 1;
     this.buy_price = buy_price;

--- a/js/item-logic.js
+++ b/js/item-logic.js
@@ -17,11 +17,12 @@ export class CraftIngredient {
    * Estructura de datos para ingredientes de crafteo y lógica de cálculo
    * @param {_parentId} string|null - Identificador del padre inmediato en el árbol, esencial para distinguir instancias compartidas.
    */
-  constructor({id, name, icon, count, parentMultiplier = 1, buy_price, sell_price, crafted_price, is_craftable, recipe, children, _parentId = null}) {
+  constructor({id, name, icon, rarity, count, parentMultiplier = 1, buy_price, sell_price, crafted_price, is_craftable, recipe, children, _parentId = null}) {
     this.modeForParentCrafted = "buy";
     this.id = id;
     this.name = name;
     this.icon = icon;
+    this.rarity = rarity;
     this.count = count;
     this.parentMultiplier = parentMultiplier || 1;
     this.buy_price = buy_price;
@@ -207,6 +208,7 @@ async function buildTreeRecursive(ingredientRecipeInfo, currentParentMultiplier,
       id: itemDetail.id,
       name: itemDetail.name,
       icon: itemDetail.icon,
+      rarity: itemDetail.rarity,
       count: ingredientRecipeInfo.count,
       parentMultiplier: currentParentMultiplier,
       buy_price: marketInfo.buy_price !== undefined ? marketInfo.buy_price : null,
@@ -309,6 +311,7 @@ async function prepareIngredientTreeData(mainItemId, mainRecipeData) {
     id: mainItemDetail.id,
     name: mainItemDetail.name,
     icon: mainItemDetail.icon,
+    rarity: mainItemDetail.rarity,
     count: 1,
     parentMultiplier: 1,
     buy_price: mainMarketInfo.buy_price,

--- a/js/item.js
+++ b/js/item.js
@@ -9,17 +9,18 @@
     window.globalQty = 1;
   }
   export class CraftIngredient {
-    constructor(id, name, icon, count, recipe, buy_price, sell_price, is_craftable, children = [], parentId = null, mode = 'buy') {
+    constructor(id, name, icon, rarity, count, recipe, buy_price, sell_price, is_craftable, children = [], parentId = null, mode = 'buy') {
       this._uid = CraftIngredient.nextUid++;
       this.id = id;
       this.name = name;
       this.icon = icon;
+      this.rarity = rarity;
       this.count = count;
       this.recipe = recipe;
       this.buy_price = buy_price;
       this.sell_price = sell_price;
       this.is_craftable = is_craftable;
-      this.children = (children || []).map(c => new CraftIngredient(c.id, c.name, c.icon, c.count, c.recipe, c.buy_price, c.sell_price, c.is_craftable, c.children, this.id, c.modeForParentCrafted));
+      this.children = (children || []).map(c => new CraftIngredient(c.id, c.name, c.icon, c.rarity, c.count, c.recipe, c.buy_price, c.sell_price, c.is_craftable, c.children, this.id, c.modeForParentCrafted));
       this._parentId = parentId;
       this.modeForParentCrafted = mode;
   
@@ -287,6 +288,7 @@ function asignarParentIds(nodos, parentId = "") {
         recipe.id,
         recipe.name,
         recipe.icon,
+        recipe.rarity,
         recipe.count || 1,
         recipe.recipe || null,
         recipe.buy_price || 0,

--- a/js/main.js
+++ b/js/main.js
@@ -207,6 +207,7 @@ async function prepareIngredientTreeData(mainItemId, mainRecipeData) {
             id: itemDetail.id,
             name: itemDetail.name,
             icon: itemDetail.icon,
+            rarity: itemDetail.rarity,
             count: ingredientRecipeInfo.count, // Cantidad necesaria para la receta padre
             parentMultiplier: currentParentMultiplier, // Output_count de la receta que produce este item
             buy_price: marketInfo.buy_price !== undefined ? marketInfo.buy_price : null,

--- a/js/utils/Ingredient1gen.js
+++ b/js/utils/Ingredient1gen.js
@@ -2,10 +2,11 @@
  * Clase que representa un ingrediente en el árbol de crafteo
  */
 export class Ingredient {
-  constructor(id, name, type, count = 1, parent = null) {
+  constructor(id, name, type, rarity = null, count = 1, parent = null) {
     this.id = id;
     this.name = name;
     this.type = type || 'crafting_material';
+    this.rarity = rarity;
     this.count = count;
     this.parent = parent;
     this.components = [];
@@ -212,6 +213,7 @@ export class Ingredient {
       id: this.id,
       name: this.name,
       type: this.type,
+      rarity: this.rarity,
       count: this.count,
       buyPrice: this._buyPrice,
       sellPrice: this._sellPrice,
@@ -227,12 +229,15 @@ export class Ingredient {
  */
 export async function createIngredientTree(itemData, parent = null) {
   if (!itemData) return null;
-  
+
+  const apiDetails = await gw2API.getItemDetails(itemData.id);
+
   // Crear el ingrediente con los datos básicos
   const ingredient = new Ingredient(
     itemData.id,
     itemData.name,
     itemData.type,
+    apiDetails?.rarity || itemData.rarity || null,
     itemData.count || 1,
     parent
   );

--- a/js/utils/Ingredient3gen.js
+++ b/js/utils/Ingredient3gen.js
@@ -5,10 +5,11 @@ import { isBasic3GenMaterial } from '../data/legendaryItems3gen.js';
  * Clase que representa un ingrediente en el árbol de crafteo
  */
 export class Ingredient {
-  constructor(id, name, type, count = 1, parent = null) {
+  constructor(id, name, type, rarity = null, count = 1, parent = null) {
     this.id = id;
     this.name = name;
     this.type = type || 'crafting_material';
+    this.rarity = rarity;
     this.count = count;
     this.parent = parent;
     this.components = [];
@@ -234,6 +235,7 @@ export class Ingredient {
       id: this.id,
       name: this.name,
       type: this.type,
+      rarity: this.rarity,
       count: this.count,
       buyPrice: this._buyPrice,
       sellPrice: this._sellPrice,
@@ -249,12 +251,15 @@ export class Ingredient {
  */
 export async function createIngredientTree(itemData, parent = null) {
   if (!itemData) return null;
-  
+
+  const apiDetails = await gw2API.getItemDetails(itemData.id);
+
   // Crear el ingrediente con los datos básicos
   const ingredient = new Ingredient(
     itemData.id,
     itemData.name,
     itemData.type,
+    apiDetails?.rarity || itemData.rarity || null,
     itemData.count || 1,
     parent
   );

--- a/js/utils/recipeUtils.js
+++ b/js/utils/recipeUtils.js
@@ -30,6 +30,7 @@ window.transformRecipeToIngredient = async function(recipe, count = 1, parentMul
             id: recipe.output_item_id,
             name: outputItem?.name || 'Ítem desconocido',
             icon: outputItem?.icon || '',
+            rarity: outputItem?.rarity,
             count: count,
             parentMultiplier: parentMultiplier,
             buy_price: prices?.buys?.unit_price || 0,
@@ -67,6 +68,7 @@ window.transformRecipeToIngredient = async function(recipe, count = 1, parentMul
                         id: ing.item_id,
                         name: itemDetails?.name || 'Ítem desconocido',
                         icon: itemDetails?.icon || '',
+                        rarity: itemDetails?.rarity,
                         count: ing.count,
                         parentMultiplier: 1, // Se ajustará en la recursión
                         buy_price: prices?.buys?.unit_price || 0,
@@ -152,6 +154,7 @@ window.loadIngredientTree = async function(ingredient, depth = 0, maxDepth = 3) 
                         id: ing.item_id,
                         name: itemDetails?.name || '',
                         icon: itemDetails?.icon || '',
+                        rarity: itemDetails?.rarity,
                         count: ing.count,
                         parentMultiplier: 1,
                         buy_price: prices?.buys?.unit_price || 0,


### PR DESCRIPTION
## Summary
- include `rarity` when transforming recipe data
- carry rarity through child ingredient creation
- fetch item details for legendary utilities and store rarity
- extend crafting ingredient classes with a `rarity` field

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6876921195e083289803fbfe2559eaf9