### PR TITLE
Apply rarity class to rendered ingredient names

### DIFF
--- a/js/legendaryCraftingBase.js
+++ b/js/legendaryCraftingBase.js
@@ -166,6 +166,7 @@ export class LegendaryCraftingBase {
 
     try {
       const iconUrl = await this.getIconUrl(ingredient);
+      const rarityClass = typeof getRarityClass === 'function' ? getRarityClass(ingredient.rarity) : '';
       const normalizedName = ingredient.name ? ingredient.name.toLowerCase() : '';
       // Buscar si este ingrediente tiene un mensaje de precio personalizado
       const customText = this.customPriceTexts.find(ct => {
@@ -223,7 +224,7 @@ export class LegendaryCraftingBase {
         <div class="${itemClass}">
           ${hasChildren ? `<button class="toggle-children" data-expanded="${isExpanded}">${isExpanded ? '−' : '+'}</button>` : '<div style="width: 24px;"></div>'}
           <img class="item-icon" src="${iconUrl}" alt="${ingredient.name || 'Item'}" title="${ingredient.name || 'Item'}" onerror="this.onerror=null;this.src='${this._getDefaultIconUrl()}';">
-          <div class="item-name">${ingredient.name || 'Item'}</div>
+          <div class="item-name ${rarityClass}">${ingredient.name || 'Item'}</div>
           <div class="item-details">
             ${ingredient.count > 1 ? `<span class="item-count">x${ingredient.count}</span>` : ''}
             <div class="item-price-container ${priceClass}" title="${priceTooltip}">


### PR DESCRIPTION
## Summary
- compute rarity class using `getRarityClass` when rendering ingredient tree entries
- apply rarity class to ingredient name element

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68769791c3b88328a4caba5b52fae3da