### PR TITLE
Display user dropdown next to avatar

### DIFF
--- a/css/global-gw.css
+++ b/css/global-gw.css
@@ -2174,8 +2174,6 @@ p .info-text{
 /* Dropdown de cuenta dentro de la barra de navegación */
 .account-dropdown {
   position: absolute;
-  top: 65px;
-  right: 32px;
   background: #1e1e1e;
   padding: 24px;
   border-radius: 8px;

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -154,16 +154,19 @@ function showAuthOptions() {
 
 // Mostrar modal con información de la cuenta
 function showAccountModal() {
-    const existing = document.getElementById('account-modal');
-    if (existing) return;
+    const existing = document.getElementById('account-dropdown');
+    if (existing) {
+        existing.remove();
+        return;
+    }
 
     const user = JSON.parse(localStorage.getItem('user') || 'null');
     if (!user) return;
 
-    const modal = document.createElement('div');
-    modal.id = 'account-modal';
-    modal.className = 'modal-overlay';
-    modal.innerHTML = `
+    const dropdown = document.createElement('div');
+    dropdown.id = 'account-dropdown';
+    dropdown.className = 'account-dropdown visible';
+    dropdown.innerHTML = `
         <div class="account-modal-content">
             <img src="${user.picture || 'https://via.placeholder.com/64'}" class="account-avatar" alt="avatar">
             <div class="account-name">${user.name || 'Usuario'}</div>
@@ -173,13 +176,29 @@ function showAccountModal() {
             <button class="close-account-btn">Cerrar</button>
         </div>
     `;
-    document.body.appendChild(modal);
 
-    const close = () => modal.remove();
-    modal.addEventListener('click', (e) => {
-        if (e.target === modal) close();
-    });
-    modal.querySelector('.close-account-btn').addEventListener('click', close);
+    document.body.appendChild(dropdown);
+
+    const userInfo = document.getElementById('userInfo');
+    if (userInfo) {
+        const rect = userInfo.getBoundingClientRect();
+        dropdown.style.top = rect.bottom + window.scrollY + 'px';
+        dropdown.style.left = rect.left + window.scrollX + 'px';
+    }
+
+    const close = () => {
+        dropdown.remove();
+        document.removeEventListener('click', outsideClick);
+    };
+
+    const outsideClick = (e) => {
+        if (!dropdown.contains(e.target) && e.target !== userInfo) {
+            close();
+        }
+    };
+
+    setTimeout(() => document.addEventListener('click', outsideClick));
+    dropdown.querySelector('.close-account-btn').addEventListener('click', close);
 }
 
 // Function to create the navigation HTML
@@ -247,7 +266,7 @@ function initNavigation() {
         nav.querySelectorAll('a.item-tab').forEach(link => {
             if (link.id !== 'userInfo') {
                 link.addEventListener('click', () => {
-                    const modal = document.getElementById('account-modal');
+                    const modal = document.getElementById('account-dropdown');
                     if (modal) modal.remove();
                 });
             }


### PR DESCRIPTION
## Summary
- position account dropdown absolutely and let JS decide location
- show dropdown below `#userInfo` instead of modal overlay
- clean up dropdown when clicking other tabs

## Testing
- `node -e "require('./js/navigation.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68787a98d1bc8328937deb1d792154cc