### PR TITLE
Centralize search modal init

### DIFF
--- a/compare-craft.html
+++ b/compare-craft.html
@@ -13,7 +13,7 @@
   </header>
   <section class="services-menu">
     <div class="menu-grid-craft">
-      <a href="#" class="menu-card-search-craft" id="open-search-modal">
+      <a href="#" class="menu-card-search-craft" id="open-search-modal" data-script="js/search-modal-compare-craft.js">
         <div class="card-icon-craft">
           <img src="img/search.svg" alt="Buscador">
         </div>
@@ -79,22 +79,6 @@
   </div>
   <script src="js/rarityUtils.js"></script>
   <script src="js/modal-utils.js"></script>
-  <script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const openBtn = document.getElementById('open-search-modal');
-    const modal = document.getElementById('search-modal');
-    const closeBtn = document.getElementById('close-search-modal');
-    openBtn.addEventListener('click', function(e) {
-      e.preventDefault();
-      openSearchModal('js/search-modal-compare-craft.js');
-    });
-    closeBtn.addEventListener('click', closeSearchModal);
-    modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape') closeSearchModal();
-    });
-  });
-  </script>
 
   <script src="js/item-tabs.js"></script>
   <script src="js/feedback-modal.js"></script>

--- a/index.html
+++ b/index.html
@@ -85,22 +85,6 @@
       </div>
       <script src="js/rarityUtils.js"></script>
       <script src="js/modal-utils.js"></script>
-      <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        const openBtn = document.getElementById('open-search-modal');
-        const modal = document.getElementById('search-modal');
-        const closeBtn = document.getElementById('close-search-modal');
-        openBtn.addEventListener('click', function(e) {
-          e.preventDefault();
-          openSearchModal();
-        });
-        closeBtn.addEventListener('click', closeSearchModal);
-        modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
-        document.addEventListener('keydown', function(e) {
-          if (e.key === 'Escape') closeSearchModal();
-        });
-      });
-      </script>
 
 
       <a href="mundo-viviente-3.html" class="menu-card">

--- a/item.html
+++ b/item.html
@@ -77,22 +77,6 @@
     </div>
   </div>
   <script src="js/modal-utils.js"></script>
-  <script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const openBtn = document.getElementById('open-search-modal');
-    const modal = document.getElementById('search-modal');
-    const closeBtn = document.getElementById('close-search-modal');
-    openBtn.addEventListener('click', function(e) {
-      e.preventDefault();
-      openSearchModal();
-    });
-    closeBtn.addEventListener('click', closeSearchModal);
-    modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape') closeSearchModal();
-    });
-  });
-  </script>
 
 <script src="js/formatGold.js"></script>
 <script defer src="js/auth.js"></script>

--- a/js/modal-utils.js
+++ b/js/modal-utils.js
@@ -30,4 +30,32 @@
     if (!modal) return;
     modal.style.display = 'none';
   };
+
+  window.initSearchModal = function() {
+    var openBtn = document.getElementById('open-search-modal');
+    var modal = document.getElementById('search-modal');
+    if (!openBtn || !modal) return;
+
+    var closeBtn = document.getElementById('close-search-modal');
+    var backdrop = modal.querySelector('.search-modal-backdrop');
+    var scriptUrl = openBtn.dataset.script || 'js/search-modal.js';
+
+    openBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      openSearchModal(scriptUrl);
+    });
+
+    if (closeBtn) closeBtn.addEventListener('click', closeSearchModal);
+    if (backdrop) backdrop.addEventListener('click', closeSearchModal);
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeSearchModal();
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', window.initSearchModal);
+  } else {
+    window.initSearchModal();
+  }
 })();


### PR DESCRIPTION
## Summary
- centralize search modal event wiring in `modal-utils.js`
- remove per-page initialization scripts
- set `compare-craft.html` button to load its own search script

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687bde2e25088328a709ec284a09476d